### PR TITLE
ダークモード設定してないと文字が全然見えなかったので大変だった

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,7 @@ body {
 
 body {
   margin: 0;
+  color: #fff;
   background: #171f29;
           /*linear-gradient(135deg, rgba(236,242,250,0.8), rgba(236,242,250,0) 40%), !* blue *!*/
           /*linear-gradient(315deg, rgba(231,242,228,0.8), rgba(231,242,228,0.3) 30%), !* green *!*/
@@ -40,10 +41,4 @@ button {
   outline: none;
   padding: 0;
   appearance: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }


### PR DESCRIPTION
## 問題点
| 通常時 | ダークモード時 |
| ------ | --------------- |
| ![通常時のスクリーンショット](https://github.com/euxn23/blog.euxn.me/assets/1996642/faebbeeb-21a7-4944-955e-c8cee8288c3d) | ![ダークモード時のスクリーンショット](https://github.com/euxn23/blog.euxn.me/assets/1996642/286b18f3-a01a-4e9a-8fcb-8c15baf97a98) |

ダークモード設定以外の人はびっくりしてしまう

## 対応

- デフォルトのテキストカラーを設定する
- ダークモード固有の適応が必要なさそうなので削除